### PR TITLE
0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@
 # How it works
 
 The extension sends a request to [QuickLaTeX](https://www.quicklatex.com/), a web service that allows you to typeset LaTeX with a simple API request. An image URI is returned, which is then fetched and transformed into a File. This File object is used to simulate a drop event in the Medium editor.
+
+# Building
+
+Running
+
+```
+node ./build.js ./build
+```
+
+produces a `Median.zip` file in the `build/` directory.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "median",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Browser extension that brings LaTeX to Medium",
   "repository": "https://github.com/Li357/median.git",
   "author": "Andrew Li",

--- a/src/background.js
+++ b/src/background.js
@@ -1,12 +1,61 @@
 /* global chrome, browser */
 
 const api = typeof chrome !== 'undefined' ? chrome : browser;
-api.webNavigation.onHistoryStateUpdated.addListener(({ tabId }) => {
-  api.tabs.executeScript(tabId, { file:'/utils.js' });
-  api.tabs.executeScript(tabId, { file:'/injector.js' });
-}, {
-  url: [
-    { urlMatches: 'https://medium.com/p/.*/edit' },
-    { urlMatches: 'https://medium.com/new-story' },
-  ],
+api.webNavigation.onHistoryStateUpdated.addListener(
+  ({ tabId }) => {
+    api.tabs.executeScript(tabId, { file: '/utils.js' });
+    api.tabs.executeScript(tabId, { file: '/injector.js' });
+  },
+  {
+    url: [{ urlMatches: 'https://medium.com/p/.*/edit' }, { urlMatches: 'https://medium.com/new-story' }],
+  },
+);
+
+api.runtime.onMessage.addListener(({ type, ...options }, sender, sendResponse) => {
+  if (type === 'getTypesetImageUri') {
+    getTypesetImageUri(options).then(sendResponse);
+  } else if (type === 'getTypesetImageBase64') {
+    getTypesetImageBase64(options).then(sendResponse);
+  }
+  return true;
 });
+
+const QUICKLATEX_BASE = 'https://quicklatex.com';
+const QUICKLATEX_API = `${QUICKLATEX_BASE}/latex3.f`;
+
+async function getTypesetImageUri({ preamble, math, fontSize, fontColor }) {
+  const response = await fetch(QUICKLATEX_API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-urlencoded' },
+    body: `preamble=${preamble}&formula=${encodeURIComponent(math)}&fsize=${`${fontSize}px`}&fcolor=${fontColor}&out=1`,
+  });
+  const text = await response.text();
+  // QuickLaTeX's response looks like this:
+  // <integer>\n
+  // <uri> <integer> <width> <height>
+  const secondLine = text.split('\n')[1];
+  const [uri] = secondLine.split(' ');
+  // we send back ONLY the latter section of the uri, i.e. /cache3/….png
+  // since we don't want unfiltered fetches allowed when the 'getTypesetImageBase64' message is sent
+  const imagePath = uri.slice(QUICKLATEX_BASE.length);
+  console.log(imagePath);
+  return imagePath;
+}
+
+function getTypesetImageBase64({ imagePath }) {
+  // fetches png as blob --> base64 (serializable)
+  return new Promise((resolve, reject) => {
+    fetch(`${QUICKLATEX_BASE}${imagePath}`)
+      .then((response) => response.blob())
+      .then((blob) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(blob);
+        reader.addEventListener('loadend', () => {
+          resolve(reader.result);
+        });
+        reader.addEventListener('error', () => {
+          reject(reader.error);
+        });
+      });
+  });
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Median",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Andrew Li",
   "description": "Browser extension that brings LaTeX to Medium",
   "permissions": [

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,7 @@
+/* global chrome, browser */
 /* exported createMathImage, createMathImageFile, placeFileIntoPost */
 
 const LATEX_USEPACKAGE_STATEMENT = /(\\usepackage.+)/g;
-
-const api = typeof chrome !== 'undefined' ? chrome : browser;
 
 function sendMessage(message) {
   const isChrome = typeof chrome !== 'undefined';


### PR DESCRIPTION
Fixes #4 by sending messages between the content and background scripts to fetch from QuickLaTeX. Uses PNGs instead of GIFs.